### PR TITLE
Update mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,6 +7,7 @@ defmodule Lapin.Mixfile do
       version: "0.1.5",
       elixir: "~> 1.5",
       description: "Elixir RabbitMQ Client",
+      source_url: "https://github.com/lucacorti/lapin",
       package: package(),
       docs: docs(),
       start_permanent: Mix.env == :prod,


### PR DESCRIPTION
This adds the source_url which makes the documentation autolink to the codebase on github.