### PR TITLE
Inspect error on logging, some errors are tuples.

### DIFF
--- a/lib/lapin/connection.ex
+++ b/lib/lapin/connection.ex
@@ -243,7 +243,7 @@ defmodule Lapin.Connection do
         Logger.warn("Broker cancelled consumer_tag '#{consumer_tag}' for locally unknown channel")
 
       {:error, error} ->
-        Logger.error("Error canceling consumer_tag '#{consumer_tag}': #{error}")
+        Logger.error("Error canceling consumer_tag '#{consumer_tag}': #{inspect(error)}")
     end
 
     {:stop, :normal, state}
@@ -389,7 +389,7 @@ defmodule Lapin.Connection do
     else
       {:error, error} ->
         Logger.error(fn ->
-          "Connection error: #{error} for #{module}, backing off for #{@backoff}"
+          "Connection error: #{inspect(error)} for #{module}, backing off for #{@backoff}"
         end)
 
         {:backoff, @backoff, state}


### PR DESCRIPTION
Connection worker dies when it receives error that is tuple.
For example `{:socket_closed_unexpectedly, :"connection.start"}` when killing RabbitMQ Docker container.
Whole application crashes because backoff strategy is not used.

Inspect error to make sure it's loggable.