### PR TITLE
Log stacktrace when rejecting a message because of an exception

### DIFF
--- a/lib/lapin/connection.ex
+++ b/lib/lapin/connection.ex
@@ -354,7 +354,10 @@ defmodule Lapin.Connection do
     exception ->
       case Consumer.reject_message(consumer, delivery_tag, not redelivered) do
         :ok ->
-          Logger.error("Rejected message #{delivery_tag}: #{inspect(exception)}")
+          Logger.error(
+            "Rejected message #{delivery_tag}: #{Exception.format(:error, exception, __STACKTRACE__)}"
+          )
+
           :ok
 
         {:error, reason} ->


### PR DESCRIPTION
Thanks for this awesome library first of all! :) We are using lapin with lots of joy over at @CitizenLabDotCo and noticed that rejected messages do print the exception that caused it, but our stack traces got lost. This PR wants to fix exactly that.

Before this change only the top level error message would be shown. We now make sure to print the whole stacktrace of the error, which makes debugging an exception much easier.

The approach seems to be the go to solution as it's mentioned in the official docs: https://elixir-lang.org/getting-started/try-catch-and-rescue.html#reraise

Edit: Just noticed there is no automated CI for PRs here: I could not run the tests yet because I don't have RabbitMQ installed on the machine, maybe you can check out the branch and make sure nothing breaks. :exclamation: 